### PR TITLE
Disabling Ungit Sticky Header If Directory Context Exists

### DIFF
--- a/lib/atom-ungit-view.coffee
+++ b/lib/atom-ungit-view.coffee
@@ -24,7 +24,7 @@ class AtomUngitView extends ScrollView
   getRepoUri: ->
     uri = "http://127.0.0.1:8448"
     if atom.project.getRootDirectory()
-      uri += "/#/repository?path=" + atom.project.getRootDirectory().path
+      uri += "/?noheader=true#/repository?path=" + atom.project.getRootDirectory().path
     uri
 
   getTitle: ->


### PR DESCRIPTION
Based on [this commit](https://github.com/FredrikNoren/ungit/issues/397) in the Ungit repository, I have added an option to hide the header section.
