### PR TITLE
rename deprecated `activationEvents` to `activationCommands`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/atom-ungit",
   "version": "0.4.3",
   "description": "Atom package for ungit",
-  "activationEvents": [
+  "activationCommands": [
     "ungit:toggle"
   ],
   "repository": "https://github.com/codingtwinky/atom-ungit",


### PR DESCRIPTION
fixes #30