### PR TITLE
changed detection of git working directory

### DIFF
--- a/lib/atom-ungit.coffee
+++ b/lib/atom-ungit.coffee
@@ -32,14 +32,8 @@ module.exports =
       n++
 
     getActiveProject = ->
-      m = 0
-      projectPaths = atom.project.getPaths()
-      if treeView
-        while m < projectPaths.length
-          if treeView.getActivePath()?.startsWith(projectPaths[m])
-            return projectPaths[m]
-          m++
-      if projectPaths then projectPaths[0] else null
+      gitRepo = atom.project.getRepositories()[0]
+      if gitRepo then gitRepo.repo.workingDirectory else null
 
     lastActiveProjectPath = getActiveProject()
 


### PR DESCRIPTION
Hello. If project root directory is git subdirectory, ungit diff loader doesn't work. We can fix it using atom api for get git working directory.